### PR TITLE
feat: Add separate Production and Sandbox installation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ _That’s it. No CLI. No scratch‑org gymnastics._
 
 | Accelerator | Version | Install Link | Docs |
 | ----------- | ------- | ------------ | ---- |
-| **Advanced Approval Starter** | `v1.4.0` | [Install](https://login.salesforce.com/packaging/installPackage.apexp?p0=04td2000000516jAAA) | [README](rca-approval/main/default/README.md) |
-| **Advanced Approval Reports** | `v1.0.0` | [Install](https://login.salesforce.com/packaging/installPackage.apexp?p0=04td2000000Ad3JAAS) | [README](rca-aa-reports/README.md) |
+| **Advanced Approval Starter** | `v1.4.0` | [Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04td2000000516jAAA) \| [Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04td2000000516jAAA) | [README](rca-approval/main/default/README.md) |
+| **Advanced Approval Reports** | `v1.0.0` | [Production](https://login.salesforce.com/packaging/installPackage.apexp?p0=04td2000000Ad3JAAS) \| [Sandbox](https://test.salesforce.com/packaging/installPackage.apexp?p0=04td2000000Ad3JAAS) | [README](rca-aa-reports/README.md) |
 
 ---
 

--- a/rca-aa-reports/README.md
+++ b/rca-aa-reports/README.md
@@ -215,11 +215,13 @@ After installing this package, users can:
 Install the managed package using the installation URL:
 
 **Latest Version:** 1.0.0-1  
-**Installation URL:** https://login.salesforce.com/packaging/installPackage.apexp?p0=04td2000000Ad3JAAS
+**Installation URLs:**
+- **Production:** https://login.salesforce.com/packaging/installPackage.apexp?p0=04td2000000Ad3JAAS
+- **Sandbox:** https://test.salesforce.com/packaging/installPackage.apexp?p0=04td2000000Ad3JAAS
 
 **Installation Steps:**
-1. Click the installation URL or copy/paste it into your browser
-2. Log in to your target org (sandbox or production)
+1. Click the appropriate installation URL for your org type (Production or Sandbox)
+2. Log in to your target org
 3. Select "Install for All Users" (recommended) or choose specific profiles
 4. Click "Install"
 5. Approve security access for the package components


### PR DESCRIPTION
- Update main README.md package index to show both Production and Sandbox links
- Update rca-aa-reports/README.md installation section with separate URLs
- Production uses login.salesforce.com base URL
- Sandbox uses test.salesforce.com base URL
- Improve clarity for users installing in different org types

Package IDs:
- Advanced Approval Starter: 04td2000000516jAAA
- Advanced Approval Reports: 04td2000000Ad3JAAS